### PR TITLE
Remove dev script tag from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
   </head>
   <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     <div id="root"></div>
-    <script type="module" src="./src/main.tsx"></script>
- 
+
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove direct TypeScript module reference from index.html so build tooling injects compiled JS

## Testing
- `npm test` *(fails: Failed to resolve import "@playwright/test"; `togglePlay` not a function)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*


------
https://chatgpt.com/codex/tasks/task_b_6891279deccc832299bba1b1328a210e