### PR TITLE
fix: load ffmpeg via CDN

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,15 +2,20 @@ import js from '@eslint/js';
 import ts from '@typescript-eslint/eslint-plugin';
 import parser from '@typescript-eslint/parser';
 import react from 'eslint-plugin-react';
+import globals from 'globals';
 
 export default [
   js.configs.recommended,
   {
     files: ['**/*.{ts,tsx}'],
-    languageOptions: { parser },
+    languageOptions: { parser, globals: globals.browser },
     plugins: { '@typescript-eslint': ts, react },
     rules: {
       'react/react-in-jsx-scope': 'off'
     }
+  },
+  {
+    files: ['public/sw.js'],
+    languageOptions: { globals: globals.serviceworker }
   }
 ];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,7 +98,9 @@ export default function App() {
   const exportRecording = async () => {
     if (!chunks.length) return;
     const blob = new Blob(chunks, { type: 'video/webm' });
-    const { createFFmpeg, fetchFile } = await (eval('import("@ffmpeg/ffmpeg")') as Promise<any>);
+    const { createFFmpeg, fetchFile } = await import(
+      'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.7/dist/ffmpeg.min.mjs'
+    );
     const ffmpeg = createFFmpeg({ log: false });
     await ffmpeg.load();
     ffmpeg.FS('writeFile', 'in.webm', await fetchFile(blob));


### PR DESCRIPTION
## Summary
- load ffmpeg from CDN to avoid MIME type issues
- configure eslint for browser and service worker globals

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689131a76b0c8322a8593b8f191c2595